### PR TITLE
Updated metrics processing commands

### DIFF
--- a/recipes/component_queue.rb
+++ b/recipes/component_queue.rb
@@ -30,6 +30,13 @@ template "/etc/init/queue.queue-storage-stats-process.conf" do
   mode 00644
 end
 
+template "/etc/init/queue.queue-elastic-stats-process.conf" do
+  source 'queue.queue-elastic-stats-process.conf.erb'
+  owner 'root'
+  group 'root'
+  mode 00644
+end
+
 cookbook_file "/etc/sudoers.d/kill" do
   source "queue_kill_sudoers"
   mode "0600"

--- a/recipes/component_queue.rb
+++ b/recipes/component_queue.rb
@@ -23,6 +23,13 @@ template "/etc/init/queue.queue-container-stats-process.conf" do
   mode 00644
 end
 
+template "/etc/init/queue.queue-storage-stats-process.conf" do
+  source 'queue.queue-storage-stats-process.conf.erb'
+  owner 'root'
+  group 'root'
+  mode 00644
+end
+
 cookbook_file "/etc/sudoers.d/kill" do
   source "queue_kill_sudoers"
   mode "0600"

--- a/recipes/component_queue_post.rb
+++ b/recipes/component_queue_post.rb
@@ -27,3 +27,14 @@ while $i <= $num  do
     end
     $i +=1
 end
+
+# storage stats
+$num = node['keboola-syrup']['queue']['storage_stats_workers_count'].to_i
+$i = 1
+while $i <= $num  do
+    execute "start storage stats queue worker N=#{$i}" do
+        command "start queue.queue-storage-stats-process N=#{$i} QUEUE=storage-stats"
+        not_if "status queue.queue-storage-stats-process N=#{$i} QUEUE=storage-stats"
+    end
+    $i +=1
+end

--- a/recipes/component_queue_post.rb
+++ b/recipes/component_queue_post.rb
@@ -38,3 +38,14 @@ while $i <= $num  do
     end
     $i +=1
 end
+
+# elastic stats
+$num = node['keboola-syrup']['queue']['elastic_stats_workers_count'].to_i
+$i = 1
+while $i <= $num  do
+    execute "start elastic stats queue worker N=#{$i}" do
+        command "start queue.queue-elastic-stats-process N=#{$i}"
+        not_if "status queue.queue-elastic-stats-process N=#{$i}"
+    end
+    $i +=1
+end

--- a/templates/default/queue.queue-container-stats-process.conf.erb
+++ b/templates/default/queue.queue-container-stats-process.conf.erb
@@ -1,3 +1,3 @@
 instance ${QUEUE}-${N}
 respawn
-exec su -s /bin/sh -c 'exec "$0" "$@"' deploy --  php /www/syrup-router/components/queue/current/vendor/keboola/syrup/app/console syrup:queue:container-stats-process $QUEUE
+exec su -s /bin/sh -c 'exec "$0" "$@"' deploy --  php /www/syrup-router/components/queue/current/vendor/keboola/syrup/app/console syrup:queue:metrics-process-container-stats $QUEUE

--- a/templates/default/queue.queue-elastic-stats-process.conf.erb
+++ b/templates/default/queue.queue-elastic-stats-process.conf.erb
@@ -1,0 +1,3 @@
+instance elastic-stats-${N}
+respawn
+exec su -s /bin/sh -c 'exec "$0" "$@"' deploy --  php /www/syrup-router/components/queue/current/vendor/keboola/syrup/app/console syrup:queue:metrics-process-elastic-stats

--- a/templates/default/queue.queue-storage-stats-process.conf.erb
+++ b/templates/default/queue.queue-storage-stats-process.conf.erb
@@ -1,0 +1,3 @@
+instance ${QUEUE}-${N}
+respawn
+exec su -s /bin/sh -c 'exec "$0" "$@"' deploy --  php /www/syrup-router/components/queue/current/vendor/keboola/syrup/app/console syrup:queue:metrics-process-storage-stats $QUEUE


### PR DESCRIPTION
Requires registered queue `storage-stats` and updated "router" templates

Related to: https://github.com/keboola/syrup-queue/pull/13

