### PR TITLE
remove gooddata cleanup writers

### DIFF
--- a/recipes/component_gooddata-writer.rb
+++ b/recipes/component_gooddata-writer.rb
@@ -13,14 +13,6 @@ cron "gooddata writer clean" do
   action action
 end
 
-cron "gooddata writer cleanup deleted projects" do
-  user "deploy"
-  hour "02"
-  minute "18"
-  command "/www/syrup-router/components/gooddata-writer/current/vendor/keboola/syrup/app/console gooddata-writer:cleanup-writers >/dev/null 2>&1"
-  action action
-end
-
 cron "gooddata writer process-invitations" do
   user "deploy"
   minute "*/5"


### PR DESCRIPTION
We are removing this because it required users super admin manage token which is not recommended for use in applications.