### PR TITLE
docker iptables

### DIFF
--- a/recipes/component_docker.rb
+++ b/recipes/component_docker.rb
@@ -70,45 +70,34 @@ if node['keboola-syrup']['docker']['install_docker'].to_i  > 0
     action :start
   end
 
-  execute "allow access to AWS DNS server" do
-    command "iptables -A FORWARD -d 10.0.0.2/32 -o eth0 -j ACCEPT"
-  end
-
-  execute "allow access to Redshift Subnet 1" do
-    command "iptables -A FORWARD -d 10.0.151.0/24 -o eth0 -j ACCEPT"
-  end
-
-  execute "allow access to Redshift Subnet 2" do
-    command "iptables -A FORWARD -d 10.0.150.0/24 -o eth0 -j ACCEPT"
-  end
-
-  execute "allow access to subnet NetHost_VPN_1a" do
-    command "iptables -A FORWARD -d 10.0.222.0/24 -o eth0 -j ACCEPT"
-  end
-
-  execute "allow access to VPN VPC subnet" do
-    command "iptables -A FORWARD -d 10.2.0.0/24 -o eth0 -j ACCEPT"
+  execute "reject connections to instance metadata" do
+    command "iptables --insert FORWARD 1 --in-interface docker+ --destination 169.254.169.254/32 --jump DROP"
   end
 
   execute "reject connections to local subnets" do
-    command "iptables -A FORWARD -d 10.0.0.0/8 -o eth0 -j REJECT --reject-with icmp-port-unreachable"
+    command "iptables --insert FORWARD 1 --in-interface docker+ --destination 10.0.0.0/8 --jump DROP"
   end
 
-  execute "reject connections to instance metadata" do
-    command "iptables -A FORWARD -d 169.254.169.254/32 -o eth0 -j REJECT --reject-with icmp-port-unreachable"
+  execute "allow access to AWS DNS server" do
+    command "iptables --insert FORWARD 1 --in-interface docker+ --destination 10.0.0.2/32 --jump ACCEPT"
   end
 
-  execute "docker iptables - 1" do
-    command "iptables -A FORWARD -o docker0 -m conntrack --ctstate RELATED,ESTABLISHED -j ACCEPT"
+  execute "allow access to Redshift Subnet 1" do
+    command "iptables --insert FORWARD 1 --in-interface docker+ --destination 10.0.151.0/24 --jump ACCEPT"
   end
 
-  execute "docker iptables - 2" do
-    command "iptables -A FORWARD -i docker0 ! -o docker0 -j ACCEPT"
+  execute "allow access to Redshift Subnet 2" do
+    command "iptables --insert FORWARD 1 --in-interface docker+ --destination 10.0.150.0/24 --jump ACCEPT"
   end
 
-  execute "docker iptables - 3" do
-    command "iptables -A FORWARD -i docker0 -o docker0 -j ACCEPT"
+  execute "allow access to subnet NetHost_VPN_1a" do
+    command "iptables --insert FORWARD 1 --in-interface docker+ --destination 10.0.222.0/24  --jump ACCEPT"
   end
+
+  execute "allow access to VPN VPC subnet" do
+    command "iptables --insert FORWARD 1 --in-interface docker+ --destination 10.2.0.0/24  --jump ACCEPT"
+  end
+
 
   if node['keboola-syrup']['enable_docker_monitoring'].to_i > 0
     include_recipe "keboola-syrup::docker-monitoring"

--- a/recipes/component_docker.rb
+++ b/recipes/component_docker.rb
@@ -70,32 +70,32 @@ if node['keboola-syrup']['docker']['install_docker'].to_i  > 0
     action :start
   end
 
-  execute "allow access to AWS DNS server" do
-    command "iptables --append DOCKER-USER --in-interface docker+ --destination 10.0.0.2/32 --jump ACCEPT"
-  end
-
-  execute "allow access to Redshift Subnet 1" do
-    command "iptables --append DOCKER-USER --in-interface docker+ --destination 10.0.151.0/24 --jump ACCEPT"
-  end
-
-  execute "allow access to Redshift Subnet 2" do
-    command "iptables --append DOCKER-USER --in-interface docker+ --destination 10.0.150.0/24 --jump ACCEPT"
-  end
-
-  execute "allow access to subnet NetHost_VPN_1a" do
-    command "iptables --append DOCKER-USER --in-interface docker+ --destination 10.0.222.0/24  --jump ACCEPT"
-  end
-
-  execute "allow access to VPN VPC subnet" do
-    command "iptables --append DOCKER-USER --in-interface docker+ --destination 10.2.0.0/24  --jump ACCEPT"
-  end
-
   execute "reject connections to local subnets" do
-    command "iptables --append DOCKER-USER --in-interface docker+ --destination 10.0.0.0/8 --jump REJECT  --reject-with icmp-port-unreachable"
+    command "iptables --insert DOCKER-USER --in-interface docker+ --destination 10.0.0.0/8 --jump REJECT  --reject-with icmp-port-unreachable"
   end
 
   execute "reject connections to instance metadata" do
-    command "iptables --append DOCKER-USER --in-interface docker+ --destination 169.254.169.254/32 --jump REJECT  --reject-with icmp-port-unreachable"
+    command "iptables --insert DOCKER-USER --in-interface docker+ --destination 169.254.169.254/32 --jump REJECT  --reject-with icmp-port-unreachable"
+  end
+
+  execute "allow access to AWS DNS server" do
+    command "iptables --insert DOCKER-USER --in-interface docker+ --destination 10.0.0.2/32 --jump ACCEPT"
+  end
+
+  execute "allow access to Redshift Subnet 1" do
+    command "iptables --insert DOCKER-USER --in-interface docker+ --destination 10.0.151.0/24 --jump ACCEPT"
+  end
+
+  execute "allow access to Redshift Subnet 2" do
+    command "iptables --insert DOCKER-USER --in-interface docker+ --destination 10.0.150.0/24 --jump ACCEPT"
+  end
+
+  execute "allow access to subnet NetHost_VPN_1a" do
+    command "iptables --insert DOCKER-USER --in-interface docker+ --destination 10.0.222.0/24  --jump ACCEPT"
+  end
+
+  execute "allow access to VPN VPC subnet" do
+    command "iptables --insert DOCKER-USER --in-interface docker+ --destination 10.2.0.0/24  --jump ACCEPT"
   end
 
   execute "save iptables" do

--- a/recipes/component_docker.rb
+++ b/recipes/component_docker.rb
@@ -66,8 +66,8 @@ if node['keboola-syrup']['docker']['install_docker'].to_i  > 0
     action :enable
   end
 
-  execute "start docker" do
-     command "service docker start"
+  service "docker" do
+    action :start, :immediately
   end
 
   execute "allow access to AWS DNS server" do

--- a/recipes/component_docker.rb
+++ b/recipes/component_docker.rb
@@ -67,7 +67,7 @@ if node['keboola-syrup']['docker']['install_docker'].to_i  > 0
   end
 
   service "docker" do
-    action :start, :immediately
+    action :start
   end
 
   execute "allow access to AWS DNS server" do

--- a/recipes/component_docker.rb
+++ b/recipes/component_docker.rb
@@ -66,8 +66,8 @@ if node['keboola-syrup']['docker']['install_docker'].to_i  > 0
     action :enable
   end
 
-  service "docker" do
-    action :start, :immediately
+  execute "start docker" do
+     command "service docker start"
   end
 
   execute "reject connections to instance metadata" do

--- a/recipes/component_docker.rb
+++ b/recipes/component_docker.rb
@@ -67,7 +67,7 @@ if node['keboola-syrup']['docker']['install_docker'].to_i  > 0
   end
 
   service "docker" do
-    action :start
+    action :start, :immediately
   end
 
   execute "reject connections to instance metadata" do


### PR DESCRIPTION
Rozbilo se po update docker. Vycházím z https://docs.aws.amazon.com/AmazonECS/latest/developerguide/instance_IAM_role.html a
https://docs.docker.com/network/iptables/

Po instalaci to vypadá takhle:
```
-P INPUT ACCEPT
-P FORWARD ACCEPT
-P OUTPUT ACCEPT
-N DOCKER
-N DOCKER-ISOLATION
-N DOCKER-USER
-A FORWARD -j DOCKER-USER
-A FORWARD -j DOCKER-ISOLATION
-A FORWARD -o docker0 -m conntrack --ctstate RELATED,ESTABLISHED -j ACCEPT
-A FORWARD -o docker0 -j DOCKER
-A FORWARD -i docker0 ! -o docker0 -j ACCEPT
-A FORWARD -i docker0 -o docker0 -j ACCEPT
-A DOCKER-ISOLATION -j RETURN
-A DOCKER-USER -d 10.2.0.0/24 -i docker+ -j ACCEPT
-A DOCKER-USER -d 10.0.222.0/24 -i docker+ -j ACCEPT
-A DOCKER-USER -d 10.0.150.0/24 -i docker+ -j ACCEPT
-A DOCKER-USER -d 10.0.151.0/24 -i docker+ -j ACCEPT
-A DOCKER-USER -d 10.0.0.2/32 -i docker+ -j ACCEPT
-A DOCKER-USER -d 169.254.169.254/32 -i docker+ -j REJECT --reject-with icmp-port-unreachable
-A DOCKER-USER -d 10.0.0.0/8 -i docker+ -j REJECT --reject-with icmp-port-unreachable
-A DOCKER-USER -j RETURN
```
