### PR TITLE
Update cadvisor app to v0.11.1

### DIFF
--- a/templates/default/docker.collect-container-stats.conf.erb
+++ b/templates/default/docker.collect-container-stats.conf.erb
@@ -10,7 +10,7 @@ exec docker run \
   -e AWS_SECRET_ACCESS_KEY=<%= node['aws']['aws_secret_access_key'] %> \
   --name=cadvisor \
   --rm \
-  quay.io/keboola/cadvisor-app:v0.10.0 \
+  quay.io/keboola/cadvisor-app:v0.11.1 \
   ./cadvisor \
   -docker_only \
   -storage_driver="amazonsqs" \


### PR DESCRIPTION
Changes

- updated tempalte to use cadvisor v0.11.1

Version v0.11.1 is based on golang 1.8 and contains latest cadvisor release.