### PR TITLE
Cron - Elastic snapshot

### DIFF
--- a/recipes/component_queue_post.rb
+++ b/recipes/component_queue_post.rb
@@ -49,3 +49,11 @@ while $i <= $num  do
     end
     $i +=1
 end
+
+cron "queue snapshot elastic" do
+    user "deploy"
+    hour "14"
+    minute "23"
+    command "/www/syrup-router/components/queue/current/vendor/keboola/syrup/app/console syrup:queue:elastic-snapshot 2>&1 | /usr/bin/logger -t 'cron_elastic_snapshot' -p local1.info"
+    action action
+end

--- a/recipes/component_queue_post.rb
+++ b/recipes/component_queue_post.rb
@@ -52,7 +52,7 @@ end
 
 cron "queue snapshot elastic" do
     user "deploy"
-    hour "14"
+    hour "21,09"
     minute "23"
     command "/www/syrup-router/components/queue/current/vendor/keboola/syrup/app/console syrup:queue:elastic-snapshot 2>&1 | /usr/bin/logger -t 'cron_elastic_snapshot' -p local1.info"
     action action


### PR DESCRIPTION
FIXES #52
Related to https://github.com/keboola/syrup-router/issues/111

Dělá dvakrát denně inkrementální snapstho Elasticu do S3.
Je to nasazené na https://syrup-testing.us-east-1.keboola.com/

Takhle to vypadá v logu:
![image](https://user-images.githubusercontent.com/903531/45015143-1525ac80-b021-11e8-90cf-1d4eae6edb2a.png)

https://papertrailapp.com/groups/5890191/events?q=program%3Acron_elastic_snapshot

