### PR TITLE
queue - drain instance

### DIFF
--- a/templates/default/queue.queue-receive.conf.erb
+++ b/templates/default/queue.queue-receive.conf.erb
@@ -1,4 +1,10 @@
 instance ${QUEUE}-${N}
 respawn
+pre-start script
+  if [ -f /home/deploy/drain-instance ]; then
+   stop
+   exit 0
+  fi
+end script
 env LANG=en_US.UTF-8
 exec su -s /bin/sh -c 'exec "$0" "$@"' deploy --  php /www/syrup-router/components/queue/current/vendor/keboola/syrup/app/console syrup:queue:receive $QUEUE $N


### PR DESCRIPTION
Alespoň jednoduchá možnost jak zrušit vybírání jobů na instanci tak aby běžící nechala doběhnout.
Zapnutí:
`touch /home/deploy/drain-instance`
Jakmile queue-receive zkusí respawn (po dvou minutách běhu pokud nemá job) tak se ukončí.

