### PR TITLE
Remove "cron" and "process-stats" commands

### DIFF
--- a/recipes/component_queue.rb
+++ b/recipes/component_queue.rb
@@ -16,27 +16,6 @@ template "/etc/init/queue.queue-receive-kill.conf" do
   notifies :restart, 'service[rsyslog]', :immediately
 end
 
-template "/etc/init/queue.queue-container-stats-process.conf" do
-  source 'queue.queue-container-stats-process.conf.erb'
-  owner 'root'
-  group 'root'
-  mode 00644
-end
-
-template "/etc/init/queue.queue-storage-stats-process.conf" do
-  source 'queue.queue-storage-stats-process.conf.erb'
-  owner 'root'
-  group 'root'
-  mode 00644
-end
-
-template "/etc/init/queue.queue-elastic-stats-process.conf" do
-  source 'queue.queue-elastic-stats-process.conf.erb'
-  owner 'root'
-  group 'root'
-  mode 00644
-end
-
 cookbook_file "/etc/sudoers.d/kill" do
   source "queue_kill_sudoers"
   mode "0600"

--- a/recipes/component_queue_post.rb
+++ b/recipes/component_queue_post.rb
@@ -17,39 +17,6 @@ while $i <= $num  do
    $i +=1
 end
 
-# container stats
-$num = node['keboola-syrup']['queue']['containers_stats_workers_count'].to_i
-$i = 1
-while $i <= $num  do
-    execute "start container stats queue worker N=#{$i}" do
-        command "start queue.queue-container-stats-process N=#{$i} QUEUE=container-stats"
-        not_if "status queue.queue-container-stats-process N=#{$i} QUEUE=container-stats"
-    end
-    $i +=1
-end
-
-# storage stats
-$num = node['keboola-syrup']['queue']['storage_stats_workers_count'].to_i
-$i = 1
-while $i <= $num  do
-    execute "start storage stats queue worker N=#{$i}" do
-        command "start queue.queue-storage-stats-process N=#{$i} QUEUE=storage-stats"
-        not_if "status queue.queue-storage-stats-process N=#{$i} QUEUE=storage-stats"
-    end
-    $i +=1
-end
-
-# elastic stats
-$num = node['keboola-syrup']['queue']['elastic_stats_workers_count'].to_i
-$i = 1
-while $i <= $num  do
-    execute "start elastic stats queue worker N=#{$i}" do
-        command "start queue.queue-elastic-stats-process N=#{$i}"
-        not_if "status queue.queue-elastic-stats-process N=#{$i}"
-    end
-    $i +=1
-end
-
 cron "queue snapshot elastic" do
     user "deploy"
     hour "21,09"

--- a/recipes/component_queue_post.rb
+++ b/recipes/component_queue_post.rb
@@ -16,11 +16,3 @@ while $i <= $num  do
    end
    $i +=1
 end
-
-cron "queue snapshot elastic" do
-    user "deploy"
-    hour "21,09"
-    minute "23"
-    command "/www/syrup-router/components/queue/current/vendor/keboola/syrup/app/console syrup:queue:elastic-snapshot 2>&1 | /usr/bin/logger -t 'cron_elastic_snapshot' -p local1.info"
-    action action
-end

--- a/templates/default/queue.queue-container-stats-process.conf.erb
+++ b/templates/default/queue.queue-container-stats-process.conf.erb
@@ -1,3 +1,0 @@
-instance ${QUEUE}-${N}
-respawn
-exec su -s /bin/sh -c 'exec "$0" "$@"' deploy --  php /www/syrup-router/components/queue/current/vendor/keboola/syrup/app/console syrup:queue:metrics-process-container-stats $QUEUE

--- a/templates/default/queue.queue-elastic-stats-process.conf.erb
+++ b/templates/default/queue.queue-elastic-stats-process.conf.erb
@@ -1,3 +1,0 @@
-instance elastic-stats-${N}
-respawn
-exec su -s /bin/sh -c 'exec "$0" "$@"' deploy --  php /www/syrup-router/components/queue/current/vendor/keboola/syrup/app/console syrup:queue:metrics-process-elastic-stats

--- a/templates/default/queue.queue-storage-stats-process.conf.erb
+++ b/templates/default/queue.queue-storage-stats-process.conf.erb
@@ -1,3 +1,0 @@
-instance ${QUEUE}-${N}
-respawn
-exec su -s /bin/sh -c 'exec "$0" "$@"' deploy --  php /www/syrup-router/components/queue/current/vendor/keboola/syrup/app/console syrup:queue:metrics-process-storage-stats $QUEUE


### PR DESCRIPTION
Related: https://github.com/keboola/queue-router/issues/4

Changes:

- Remove cron for elastic-snapshot
- Remove 3 process-stats commands

---

Vyhodil som s tym cronom rovno aj tie 3 process-stats. Vacsi cleanup tam nejdem riesit, zmazeme to naraz.